### PR TITLE
Add Node.js 12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-protobuf",
-  "version": "1.5.0-dx",
+  "version": "1.6.0",
   "description": "A Node.js protocol buffer wrapper",
   "author": "Dmitry Gorbunov <atskiisotona@gmail.com",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-protobuf",
-  "version": "1.5.0",
+  "version": "1.5.0-dx",
   "description": "A Node.js protocol buffer wrapper",
   "author": "Dmitry Gorbunov <atskiisotona@gmail.com",
   "license": "MIT",

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -15,100 +15,100 @@ void SerializeField(Isolate *isolate, google::protobuf::Message *message,
     switch (field->cpp_type()) {
     case FieldDescriptor::CPPTYPE_INT32: {
       if (repeated)
-        r->AddInt32(message, field, val->Int32Value());
+        r->AddInt32(message, field, Nan::To<int32_t>(val).FromMaybe(0));
       else
-        r->SetInt32(message, field, val->Int32Value());
+        r->SetInt32(message, field, Nan::To<int32_t>(val).FromMaybe(0));
       break;
     }
     case FieldDescriptor::CPPTYPE_INT64:
       if (repeated)
         if (preserve_int64 && val->IsArray()) {
-          Local<Object> n64_array = val->ToObject();
+          Local<Object> n64_array = val->ToObject(isolate);
           uint64 n64;
-          uint32 hi = n64_array->Get(0)->Uint32Value(),
-                 lo = n64_array->Get(1)->Uint32Value();
+          uint32_t hi = Nan::To<uint32_t>(n64_array->Get(0)).FromMaybe(0),
+                 lo = Nan::To<uint32_t>(n64_array->Get(1)).FromMaybe(0);
           n64 = ((uint64)hi << 32) + (uint64)lo;
           r->AddInt64(message, field, n64);
         } else if (preserve_int64 && val->IsString()) {
-          String::Utf8Value temp(isolate, val->ToString());
+          Nan::Utf8String temp(val->ToString(isolate));
           std::string value = std::string(*temp);
           r->AddInt64(message, field, std::stoll(value, nullptr, 10));
         } else
-          r->AddInt64(message, field, val->NumberValue());
+          r->AddInt64(message, field, Nan::To<int64_t>(val).FromMaybe(0));
       else if (preserve_int64 && val->IsArray()) {
-        Local<Object> n64_array = val->ToObject();
+        Local<Object> n64_array = val->ToObject(isolate);
         uint64 n64;
-        uint32 hi = n64_array->Get(0)->Uint32Value(),
-               lo = n64_array->Get(1)->Uint32Value();
+        uint32_t hi = Nan::To<uint32_t>(n64_array->Get(0)).FromMaybe(0),
+                 lo = Nan::To<uint32_t>(n64_array->Get(1)).FromMaybe(0);
         n64 = ((uint64)hi << 32) + (uint64)lo;
         r->SetInt64(message, field, n64);
       } else if (preserve_int64 && val->IsString()) {
-        String::Utf8Value temp(isolate, val->ToString());
+        Nan::Utf8String temp(val->ToString(isolate));
         std::string value = std::string(*temp);
         r->SetInt64(message, field, std::stoll(value, nullptr, 10));
       } else
-        r->SetInt64(message, field, val->NumberValue());
+        r->SetInt64(message, field, Nan::To<int64_t>(val).FromMaybe(0));
       break;
     case FieldDescriptor::CPPTYPE_UINT32:
       if (repeated)
-        r->AddUInt32(message, field, val->Uint32Value());
+        r->AddUInt32(message, field, Nan::To<uint32_t>(val).FromMaybe(0));
       else
-        r->SetUInt32(message, field, val->Uint32Value());
+        r->SetUInt32(message, field, Nan::To<uint32_t>(val).FromMaybe(0));
       break;
     case FieldDescriptor::CPPTYPE_UINT64:
       if (repeated)
         if (preserve_int64 && val->IsArray()) {
-          Local<Object> n64_array = val->ToObject();
+          Local<Object> n64_array = val->ToObject(isolate);
           uint64 n64;
-          uint32 hi = n64_array->Get(0)->Uint32Value(),
-                 lo = n64_array->Get(1)->Uint32Value();
+          uint32_t hi = Nan::To<uint32_t>(n64_array->Get(0)).FromMaybe(0),
+                 lo = Nan::To<uint32_t>(n64_array->Get(1)).FromMaybe(0);
           n64 = ((uint64)hi << 32) + (uint64)lo;
           r->AddUInt64(message, field, n64);
         } else if (preserve_int64 && val->IsString()) {
-          String::Utf8Value temp(isolate, val->ToString());
+          Nan::Utf8String temp(val->ToString(isolate));
           std::string value = std::string(*temp);
           r->AddUInt64(message, field, std::stoull(value, nullptr, 10));
         } else
-          r->AddUInt64(message, field, val->NumberValue());
+          r->AddUInt64(message, field, Nan::To<int64_t>(val).FromMaybe(0));
       else if (preserve_int64 && val->IsArray()) {
-        Local<Object> n64_array = val->ToObject();
+        Local<Object> n64_array = val->ToObject(isolate);
         uint64 n64;
-        uint32 hi = n64_array->Get(0)->Uint32Value(),
-               lo = n64_array->Get(1)->Uint32Value();
+        uint32_t hi = Nan::To<uint32_t>(n64_array->Get(0)).FromMaybe(0),
+                 lo = Nan::To<uint32_t>(n64_array->Get(1)).FromMaybe(0);
         n64 = ((uint64)hi << 32) + (uint64)lo;
         r->SetUInt64(message, field, n64);
       } else if (preserve_int64 && val->IsString()) {
-        String::Utf8Value temp(isolate, val->ToString());
+        Nan::Utf8String temp(val->ToString(isolate));
         std::string value = std::string(*temp);
         r->SetUInt64(message, field, std::stoull(value, nullptr, 10));
       } else {
-        r->SetUInt64(message, field, val->NumberValue());
+        r->SetUInt64(message, field, Nan::To<int64_t>(val).FromMaybe(0));
       }
       break;
     case FieldDescriptor::CPPTYPE_DOUBLE:
       if (repeated)
-        r->AddDouble(message, field, val->NumberValue());
+        r->AddDouble(message, field, Nan::To<double>(val).FromMaybe(0));
       else
-        r->SetDouble(message, field, val->NumberValue());
+        r->SetDouble(message, field, Nan::To<double>(val).FromMaybe(0));
       break;
     case FieldDescriptor::CPPTYPE_FLOAT:
       if (repeated)
-        r->AddFloat(message, field, val->NumberValue());
+        r->AddFloat(message, field, Nan::To<double>(val).FromMaybe(0));
       else
-        r->SetFloat(message, field, val->NumberValue());
+        r->SetFloat(message, field, Nan::To<double>(val).FromMaybe(0));
       break;
     case FieldDescriptor::CPPTYPE_BOOL:
       if (repeated)
-        r->AddBool(message, field, val->BooleanValue());
+        r->AddBool(message, field, val->BooleanValue(isolate));
       else
-        r->SetBool(message, field, val->BooleanValue());
+        r->SetBool(message, field, val->BooleanValue(isolate));
       break;
     case FieldDescriptor::CPPTYPE_ENUM:
       // TODO: possible memory leak?
       enumValue = val->IsNumber()
-                      ? field->enum_type()->FindValueByNumber(val->Int32Value())
+                      ? field->enum_type()->FindValueByNumber(Nan::To<int32_t>(val).FromMaybe(0))
                       : field->enum_type()->FindValueByName(
-                            *String::Utf8Value(isolate, val));
+                            *Nan::Utf8String(val));
 
       if (enumValue != NULL) {
         if (repeated)
@@ -129,7 +129,7 @@ void SerializeField(Isolate *isolate, google::protobuf::Message *message,
       break;
     case FieldDescriptor::CPPTYPE_STRING:
       if (Buffer::HasInstance(val)) {
-        Local<Object> buf = val->ToObject();
+        Local<Object> buf = val->ToObject(isolate);
         if (repeated)
           r->AddString(message, field,
                        std::string(Buffer::Data(buf), Buffer::Length(buf)));
@@ -139,26 +139,26 @@ void SerializeField(Isolate *isolate, google::protobuf::Message *message,
         break;
       }
 
-      if (val->IsObject()) {
-        Local<Object> val2 = val->ToObject();
-        Local<Value> converter =
-            val2->Get(Nan::New<String>("toProtobuf").ToLocalChecked());
-        if (converter->IsFunction()) {
-          Local<Function> toProtobuf = Local<Function>::Cast(converter);
-          Local<Value> ret = toProtobuf->Call(val2, 0, NULL);
-          if (Buffer::HasInstance(ret)) {
-            Local<Object> buf = ret->ToObject();
-            if (repeated)
-              r->AddString(message, field,
-                           std::string(Buffer::Data(buf), Buffer::Length(buf)));
-            else
-              r->SetString(message, field,
-                           std::string(Buffer::Data(buf), Buffer::Length(buf)));
-            break;
-          }
-        }
-      }
-      String::Utf8Value temp(isolate, val->ToString());
+      // if (val->IsObject()) {
+      //   Local<Object> val2 = val->ToObject(isolate);
+      //   Local<Value> converter =
+      //       val2->Get(Nan::New<String>("toProtobuf").ToLocalChecked());
+      //   if (converter->IsFunction()) {
+      //     Local<Function> toProtobuf = Local<Function>::Cast(converter);
+      //     Local<Value> ret = toProtobuf->Call(val2, 0, NULL);
+      //     if (Buffer::HasInstance(ret)) {
+      //       Local<Object> buf = ret->ToObject(isolate);
+      //       if (repeated)
+      //         r->AddString(message, field,
+      //                      std::string(Buffer::Data(buf), Buffer::Length(buf)));
+      //       else
+      //         r->SetString(message, field,
+      //                      std::string(Buffer::Data(buf), Buffer::Length(buf)));
+      //       break;
+      //     }
+      //   }
+      // }
+      Nan::Utf8String temp(val->ToString(isolate));
       std::string value = std::string(*temp);
       if (repeated)
         r->AddString(message, field, value);

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,14 @@ var p = require("../protobuf")
 var pb = new p(fs.readFileSync(__dirname + "/test.desc"))
 var pbUnknown = new p(fs.readFileSync(__dirname + "/testUnknown.desc"))
 
+function deepEqualLoose(a1, a2) {
+  assert.equal(a1.length, a2.length)
+
+  for (let i = 0; i < a1.length; i++) {
+    assert.equal(a1[i], a2[i])
+  }
+}
+
 describe("Basic", function() {
 	var obj = {
 		"name": "test",
@@ -136,7 +144,7 @@ describe("Basic", function() {
 			var buffer = pb.serialize(obj, "tk.tewi.Test")
 			var parsed = pb.parse(buffer, "tk.tewi.Test", null, null, null, false);
 
-			assert.deepEqual(obj.r, parsed.r)
+			deepEqualLoose(obj.r, parsed.r)
 			assert.notEqual(parsed.r instanceof Int32Array, true,
 				'Should not be an Int32Array');
 		})
@@ -262,7 +270,7 @@ describe("Basic", function() {
 			var buffer = pb.serialize(obj, "tk.tewi.Test")
 			var parsed = pb.parseWithUnknown(buffer, "tk.tewi.Test", null, null, null, false);
 
-			assert.deepEqual(obj.r, parsed.r)
+		  deepEqualLoose(obj.r, parsed.r)
 			assert.notEqual(parsed.r instanceof Int32Array, true,
 				'Should not be an Int32Array');
 		})


### PR DESCRIPTION
Add support for Node.js 12

Tests:

```
yarn run v1.16.0
$ ./node_modules/.bin/mocha ./test/test.js -R spec


  Basic
    Serialize
      ✓ Should serialize object according to schema
      ✓ Should throw an error on invalid schema
      ✓ Should throw an error on missing required fields
      ✓ Should throw an error on null required fields
      ✓ Should serialize asynchronously
    Parse
      ✓ Should parse a buffer and return exactly the same object
      ✓ Should do previous step asynchronously
      ✓ Should throw an error on invalid argument
      ✓ Should throw an error on invalid buffer
(node:17554) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
      ✓ Should throw an error on invalid schema
      ✓ Should ignore optional null fields
      ✓ Should ignore optional undefined fields
      ✓ Should return repeated int32 fields as typed array
      ✓ Should return repeated int32 fields as non-typed array
    Parse With Unknown
use_typed_array 1
      ✓ Should parse a buffer and return exactly the same object
use_typed_array 1
      ✓ Should do previous step asynchronously
      ✓ Should throw an error on invalid argument
      ✓ Should throw an error on invalid buffer
      ✓ Should throw an error on invalid schema
use_typed_array 1
      ✓ Should ignore optional null fields
use_typed_array 1
      ✓ Should ignore optional undefined fields
use_typed_array 1
      ✓ Should tell us about unknownFields
use_typed_array 1
      ✓ Should return repeated int32 fields as typed array
use_typed_array 0
      ✓ Should return repeated int32 fields as non-typed array
    Info
      ✓ Should return correct info about descriptor
    Behaviour
      ✓ Should return empty repeated as empty arrays


  26 passing (22ms)

Done in 0.27s.
```